### PR TITLE
Manage a single curator

### DIFF
--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -114,10 +114,13 @@ public class PersistentWatcher implements Closeable {
   //@Override Java 5 compatibility
   public void close() throws IOException {
     if (closed.compareAndSet(false, true)) {
-      listeners.clear();
-      lastVersion.set(-1);
-      executor.shutdown();
-      parent.recordClose();
+      try {
+        listeners.clear();
+        lastVersion.set(-1);
+        executor.shutdown();
+      } finally {
+        parent.recordClose();
+      }
     }
   }
 

--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -117,6 +117,7 @@ public class PersistentWatcher implements Closeable {
       listeners.clear();
       lastVersion.set(-1);
       executor.shutdown();
+      parent.recordClose();
     }
   }
 

--- a/src/main/java/com/hubspot/ringleader/watcher/WatcherFactory.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/WatcherFactory.java
@@ -35,7 +35,7 @@ public class WatcherFactory {
   private final ScheduledExecutorService executor;
 
   public WatcherFactory(Supplier<CuratorFramework> curatorSupplier) {
-    this(curatorSupplier, getExecutor());
+    this(curatorSupplier, newExecutor());
   }
 
   @VisibleForTesting
@@ -220,7 +220,7 @@ public class WatcherFactory {
     }
   }
 
-  private static ScheduledExecutorService getExecutor() {
+  private static ScheduledExecutorService newExecutor() {
     return Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
       //@Override Java 5 compatibility
       public Thread newThread(Runnable r) {

--- a/src/main/java/com/hubspot/ringleader/watcher/WatcherFactory.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/WatcherFactory.java
@@ -1,25 +1,64 @@
 package com.hubspot.ringleader.watcher;
 
-import com.google.common.base.Supplier;
-import org.apache.curator.framework.CuratorFramework;
-
+import java.lang.reflect.Field;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.UnhandledErrorListener;
+import org.apache.curator.framework.imps.CuratorFrameworkState;
+import org.apache.curator.framework.state.ConnectionState;
+import org.apache.curator.framework.state.ConnectionStateListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Supplier;
 
 public class WatcherFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(WatcherFactory.class);
   private final Supplier<CuratorFramework> curatorSupplier;
+
+  private final AtomicReference<CuratorFramework> curatorReference;
+  private final AtomicLong curatorTimestamp;
+  private final AtomicBoolean started;
+  private final AtomicBoolean closed;
+  private final ScheduledExecutorService executor;
 
   public WatcherFactory(Supplier<CuratorFramework> curatorSupplier) {
     this.curatorSupplier = curatorSupplier;
+    this.curatorReference = new AtomicReference<CuratorFramework>();
+    this.curatorTimestamp = new AtomicLong(0);
+    this.started = new AtomicBoolean();
+    this.closed = new AtomicBoolean();
+    this.executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+      //@Override Java 5 compatibility
+      public Thread newThread(Runnable r) {
+        Thread thread = Executors.defaultThreadFactory().newThread(r);
+        thread.setName("WatcherFactoryExecutor");
+        thread.setDaemon(true);
+        return thread;
+      }
+    });
   }
 
   public PersistentWatcher dataWatcher(String path) {
-    return new PersistentWatcher(curatorSupplier, path);
+    startIfNecessary();
+
+    return new PersistentWatcher(this, path);
   }
 
   public PersistentWatcher blockingDataWatcher(String path) {
+    startIfNecessary();
+
     final CountDownLatch started = new CountDownLatch(1);
 
-    PersistentWatcher watcher = new PersistentWatcher(curatorSupplier, path) {
+    PersistentWatcher watcher = new PersistentWatcher(this, path) {
 
       @Override
       public void start() {
@@ -41,5 +80,111 @@ public class WatcherFactory {
     });
 
     return watcher;
+  }
+
+  AtomicReference<CuratorFramework> getCurator() {
+    return curatorReference;
+  }
+
+  synchronized void replaceCurator(final Runnable runnable) {
+    long timestamp = curatorTimestamp.get();
+    long age = System.currentTimeMillis() - timestamp;
+    long minAge = TimeUnit.MINUTES.toMillis(1);
+
+    // only attempt reconnect once per minute so we don't exacerbate a failure scenario and don't reconnect when the
+    // executor is shutting down.
+    if (age < minAge || !curatorTimestamp.compareAndSet(timestamp, System.currentTimeMillis()) || executor.isShutdown()) {
+      return;
+    }
+
+    executor.submit(new Runnable() {
+
+      //@Override Java 5 compatibility
+      public void run() {
+        CuratorFramework previous = curatorReference.getAndSet(createNewCurator());
+        cleanup(previous);
+        if (runnable != null) {
+          runnable.run();
+        }
+      }
+    });
+  }
+
+  private void startIfNecessary() {
+    if (started.compareAndSet(false, true)) {
+      curatorReference.set(createNewCurator());
+    }
+  }
+
+  private CuratorFramework createNewCurator() {
+    CuratorFramework curator = null;
+    try {
+      curator = curatorSupplier.get();
+      if (curator.getState() != CuratorFrameworkState.STARTED) {
+        curator.start();
+      }
+
+      curator.getConnectionStateListenable().addListener(new ConnectionStateListener() {
+
+        //@Override Java 5 compatibility
+        public void stateChanged(CuratorFramework client, ConnectionState newState) {
+          switch (newState) {
+            case SUSPENDED:
+            case LOST:
+              LOG.error("Connection lost or suspended, replacing client");
+              replaceCurator(null);
+              break;
+            default:
+              // make findbugs happy
+          }
+        }
+      });
+
+      curator.getUnhandledErrorListenable().addListener(new UnhandledErrorListener() {
+
+        //@Override Java 5 compatibility
+        public void unhandledError(String message, Throwable e) {
+          LOG.error("Curator error, replacing client", e);
+          replaceCurator(null);
+        }
+      });
+
+      return curator;
+    } catch (Exception e) {
+      LOG.error("Error creating curator", e);
+      cleanup(curator);
+      return null;
+    }
+  }
+
+  private void cleanup(final CuratorFramework curator) {
+    if (curator == null) {
+      return;
+    }
+
+    executor.submit(new Runnable() {
+
+      //@Override Java 5 compatibility
+      public void run() {
+        try {
+          close(curator);
+        } catch (Exception e) {
+          LOG.debug("Error closing curator", e);
+        }
+      }
+
+      private void close(CuratorFramework curator) throws Exception {
+        try {
+          curator.close();
+        } catch (UnsupportedOperationException e) {
+          // NamespaceFacade throws UnsupportedOperationException when you try to close it
+          // Need to resort to reflection to access real CuratorFramework instance so we can close it
+          Field curatorField = curator.getClass().getDeclaredField("client");
+          curatorField.setAccessible(true);
+
+          close((CuratorFramework) curatorField.get(curator));
+        }
+      }
+    });
   }
 }

--- a/src/test/java/com/hubspot/ringleader/watcher/PersistentWatcherTest.java
+++ b/src/test/java/com/hubspot/ringleader/watcher/PersistentWatcherTest.java
@@ -1,7 +1,13 @@
 package com.hubspot.ringleader.watcher;
 
-import com.google.common.base.Supplier;
-import com.hubspot.ringleader.watcher.Event.Type;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -13,13 +19,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import com.google.common.base.Supplier;
+import com.hubspot.ringleader.watcher.Event.Type;
 
 public class PersistentWatcherTest {
   private static final String PATH = "/test";
@@ -94,7 +95,7 @@ public class PersistentWatcherTest {
     watcher.start();
 
     waitForEvents();
-    assertThat(curatorCounter.get()).isEqualTo(1);
+    assertThat(curatorCounter.get()).isEqualTo(2);
     assertThat(events).hasSize(1);
     assertThat(events.get(0).getType()).isEqualTo(Type.NODE_UPDATED);
     assertThat(events.get(0).getStat().getVersion()).isEqualTo(0);
@@ -167,7 +168,7 @@ public class PersistentWatcherTest {
     watcher = newBlockingWatcher(delayedSupplier);
     watcher.start();
 
-    assertThat(curatorCounter.get()).isEqualTo(1);
+    assertThat(curatorCounter.get()).isEqualTo(2);
     assertThat(events).hasSize(1);
     assertThat(events.get(0).getType()).isEqualTo(Type.NODE_UPDATED);
     assertThat(events.get(0).getStat().getVersion()).isEqualTo(0);


### PR DESCRIPTION
This updates `PersistentWatcher`s to be backed by a single curator managed by their parent `WatcherFactory` to provide better behavior when many `PersistentWatcher`s are needed

@jhaber @stevegutz 