### PR TITLE
Refactor WatcherFactory to ensure fetch is always called

### DIFF
--- a/src/main/java/com/hubspot/ringleader/watcher/Event.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/Event.java
@@ -2,8 +2,6 @@ package com.hubspot.ringleader.watcher;
 
 import org.apache.zookeeper.data.Stat;
 
-import java.util.Arrays;
-
 public class Event {
   public enum Type {
     NODE_UPDATED, NODE_DELETED

--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -63,7 +63,7 @@ public class PersistentWatcher implements Closeable {
             notifyListeners(Event.nodeDeleted());
             break;
           default:
-            fetch(false);
+            fetchInExecutor();
         }
       }
     };
@@ -93,18 +93,12 @@ public class PersistentWatcher implements Closeable {
 
   public void start() {
     if (started.compareAndSet(false, true)) {
-      executor.submit(new Runnable() {
-
-        //@Override Java 5 compatibility
-        public void run() {
-          try {
-            fetch(true);
-          } finally {
-            executor.schedule(this, 10, TimeUnit.MINUTES);
-          }
-        }
-      });
+      fetchInExecutor();
     }
+  }
+
+  public boolean isStarted() {
+    return started.get();
   }
 
   public Listenable<EventListener> getEventListenable() {
@@ -119,17 +113,30 @@ public class PersistentWatcher implements Closeable {
         lastVersion.set(-1);
         executor.shutdown();
       } finally {
-        parent.recordClose();
+        parent.recordClose(this);
       }
     }
   }
 
-  private synchronized void fetch(final boolean backgroundFetch) {
+  void fetchInExecutor() {
+    executor.submit(new Runnable() {
+      //@Override Java 5 compatibility
+      public void run() {
+        try {
+          fetch();
+        } finally {
+          executor.schedule(this, 10, TimeUnit.MINUTES);
+        }
+      }
+    });
+  }
+
+  private synchronized void fetch() {
     try {
       CuratorFramework curator = parent.getCurator().get();
       if (curator == null) {
         LOG.error("No curator present, replacing client");
-        replaceCurator(backgroundFetch);
+        parent.replaceCurator();
         return;
       }
 
@@ -141,13 +148,9 @@ public class PersistentWatcher implements Closeable {
 
       int version = stat.getVersion();
       int previousVersion = lastVersion.getAndSet(version);
+
       if (version != previousVersion) {
         notifyListeners(Event.nodeUpdated(stat, data));
-
-        if (previousVersion != -1 && backgroundFetch) {
-          LOG.error("Watcher stopped firing, replacing client");
-          replaceCurator(backgroundFetch);
-        }
       }
     } catch (NoNodeException e) {
       LOG.debug("No node exists for path {}", path);
@@ -156,7 +159,7 @@ public class PersistentWatcher implements Closeable {
       }
     } catch (Exception e) {
       LOG.error("Error fetching data, replacing client", e);
-      replaceCurator(backgroundFetch);
+      parent.replaceCurator();
     }
   }
 
@@ -171,20 +174,6 @@ public class PersistentWatcher implements Closeable {
           public Void apply(EventListener listener) {
             listener.newEvent(event);
             return null;
-          }
-        });
-      }
-    });
-  }
-
-  private void replaceCurator(final boolean backgroundFetch) {
-    parent.replaceCurator(new Runnable() {
-      @Override
-      public void run() {
-        executor.submit(new Runnable() {
-          @Override
-          public void run() {
-            fetch(backgroundFetch);
           }
         });
       }

--- a/src/test/java/com/hubspot/ringleader/watcher/PersistentWatcherTest.java
+++ b/src/test/java/com/hubspot/ringleader/watcher/PersistentWatcherTest.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -190,7 +191,7 @@ public class PersistentWatcherTest {
       }
     });
 
-    WatcherFactory factory = new WatcherFactory(curatorSupplier, executor);
+    WatcherFactory factory = new WatcherFactory(curatorSupplier, executor, TimeUnit.MINUTES.toMillis(1));
     PersistentWatcher watcher1 = factory.dataWatcher(PATH);
     PersistentWatcher watcher2 = factory.dataWatcher(PATH);
     PersistentWatcher watcher3 = factory.dataWatcher(PATH);

--- a/src/test/java/com/hubspot/ringleader/watcher/ReconnectTest.java
+++ b/src/test/java/com/hubspot/ringleader/watcher/ReconnectTest.java
@@ -1,0 +1,173 @@
+package com.hubspot.ringleader.watcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.BindException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.curator.test.DirectoryUtils;
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
+import org.apache.zookeeper.data.Stat;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.base.Supplier;
+import com.google.common.io.Files;
+import com.google.common.primitives.Longs;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+public class ReconnectTest {
+  private static final int SESSION_TIMEOUT_MS = 5000;
+  private static final String PATH = "/test";
+
+  private File sharedDataDirectory = Files.createTempDir();
+  private List<TestingServer> servers = new ArrayList<>();
+  private List<Event> events = new ArrayList<>();
+
+  private Supplier<CuratorFramework> curatorSupplier;
+  private PersistentWatcher watcher;
+  private ScheduledExecutorService executor;
+
+  @Before
+  public void setup() {
+    sharedDataDirectory = Files.createTempDir();
+
+    curatorSupplier = new Supplier<CuratorFramework>() {
+      //@Override Java 5 compatibility
+      public CuratorFramework get() {
+        CuratorFramework curator = CuratorFrameworkFactory.builder()
+            .connectString(getCurrentServer().getConnectString())
+            .sessionTimeoutMs(SESSION_TIMEOUT_MS)
+            .connectionTimeoutMs(1000)
+            .retryPolicy(new ExponentialBackoffRetry(100, 3))
+            .build();
+
+        curator.start();
+
+        return curator;
+      }
+    };
+
+    servers.add(createNewServer());
+    createData();
+
+    executor = Executors.newSingleThreadScheduledExecutor(
+        new ThreadFactoryBuilder().setDaemon(true).build());
+
+    watcher = new WatcherFactory(curatorSupplier, executor, 5000).dataWatcher(PATH);
+    watcher.getEventListenable().addListener(new EventListener() {
+
+      //@Override Java 5 compatibility
+      public void newEvent(Event event) {
+        events.add(event);
+      }
+    });
+  }
+
+  @After
+  public void after() throws IOException {
+    executor.shutdownNow();
+
+    for (TestingServer server : servers) {
+      server.stop();
+      server.close();
+    }
+
+    DirectoryUtils.deleteRecursively(sharedDataDirectory);
+  }
+
+  @Test
+  public void itReconnectsAfterRepeatedFailures()  {
+    watcher.start();
+    assertWatcherIsRespondingToEvents();
+
+    servers.add(createNewServer());
+    assertWatcherIsRespondingToEvents();
+
+    servers.add(createNewServer());
+    assertWatcherIsRespondingToEvents();
+
+    servers.add(createNewServer());
+    assertWatcherIsRespondingToEvents();
+  }
+
+  private void assertWatcherIsRespondingToEvents() {
+    events.clear();
+
+    setData(Longs.toByteArray(System.currentTimeMillis()));
+
+    long millisToWait = 10_000L;
+    long startedAt = System.currentTimeMillis();
+    while (System.currentTimeMillis() < startedAt + millisToWait) {
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+
+      if (!events.isEmpty()) {
+        return;
+      }
+    }
+
+    throw new RuntimeException("Did not respond to events!");
+  }
+
+  private void createData() {
+    CuratorFramework curatorFramework = curatorSupplier.get();
+    try {
+      curatorFramework.create().forPath(PATH, "0".getBytes());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      curatorFramework.close();
+    }
+  }
+
+  private void setData(byte[] newData) {
+    CuratorFramework curatorFramework = curatorSupplier.get();
+    try {
+      Stat stat = curatorFramework.setData().forPath(PATH, newData);
+      stat.getVersion();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      curatorFramework.close();
+    }
+  }
+
+  private TestingServer createNewServer() {
+    try {
+      if (!servers.isEmpty()) {
+        TestingServer previousServer = getCurrentServer();
+        previousServer.stop();
+        previousServer.close();
+      }
+
+      TestingServer testingServer = new TestingServer(new InstanceSpec(sharedDataDirectory, -1, -1, -1, false, -1), true);
+      testingServer.start();
+
+      return testingServer;
+    } catch (BindException e) {
+      // this can happen due a race when creating TestingServer
+      return createNewServer();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private TestingServer getCurrentServer() {
+    assertThat(servers.isEmpty()).withFailMessage("There are no active servers").isFalse();
+    return servers.get(servers.size() - 1);
+  }
+}


### PR DESCRIPTION
Every started instance of PersistentWatcher must re-fetch its configured path when the curator is replaced. Previously, this mostly happened by passing a runnable to the replaceCurator method. If there are several watchers and they all call replaceCurator on their parent however, only one will have fetch called.

Instead, we track created PersistentWatchers and instruct each to fetch when the curator is replaced. This ensures we always subscribe to new change events and simplifies the code.