### PR TITLE
Make the fetch periodic

### DIFF
--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -79,7 +79,7 @@ public class PersistentWatcher implements Closeable {
     if (started.compareAndSet(false, true)) {
       fetchInExecutor();
 
-      executor.schedule(() -> {
+      executor.scheduleAtFixedRate(() -> {
         int versionBeforeFetch = lastVersion.get();
         fetch();
 
@@ -87,7 +87,7 @@ public class PersistentWatcher implements Closeable {
           LOG.error("Detected a change that didn't raise an event; replacing curator");
           parent.replaceCurator();
         }
-      }, 10, TimeUnit.MINUTES);
+      }, 1, 1, TimeUnit.MINUTES);
     }
   }
 

--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -80,11 +80,16 @@ public class PersistentWatcher implements Closeable {
       fetchInExecutor();
 
       executor.scheduleAtFixedRate(() -> {
-        int versionBeforeFetch = lastVersion.get();
-        fetch();
+        try {
+          int versionBeforeFetch = lastVersion.get();
+          fetch();
 
-        if (lastVersion.get() != versionBeforeFetch) {
-          LOG.error("Detected a change that didn't raise an event; replacing curator");
+          if (lastVersion.get() != versionBeforeFetch) {
+            LOG.error("Detected a change that didn't raise an event; replacing curator");
+            parent.replaceCurator();
+          }
+        } catch (Throwable t) {
+          LOG.error("Error fetching data, replacing client", t);
           parent.replaceCurator();
         }
       }, 1, 1, TimeUnit.MINUTES);


### PR DESCRIPTION
This fetch used to re-schedule itself, but that got lost in some refactoring. This updates is so that the background fetch is scheduled to repeat on an interval and also drops the interval way down to a minute.

@mcobrien @jschlather @ssalinas 