### PR TITLE
Switch error to warn

### DIFF
--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -85,7 +85,7 @@ public class PersistentWatcher implements Closeable {
           fetch();
 
           if (lastVersion.get() != versionBeforeFetch) {
-            LOG.error("Detected a change that didn't raise an event; replacing curator");
+            LOG.warn("Detected a change that didn't raise an event; replacing curator");
             parent.replaceCurator();
           }
         } catch (Throwable t) {


### PR DESCRIPTION
Seems like this `error` is comes up frequently and creates noise in our error reporting. Suggesting we switch this to a `warn`.

cc @jhaber @stevegutz 