### PR TITLE
Switch from deprecated ListenerContainer to StandardListenerManager

### DIFF
--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -13,6 +13,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.api.CuratorWatcher;
 import org.apache.curator.framework.listen.Listenable;
 import org.apache.curator.framework.listen.ListenerContainer;
+import org.apache.curator.framework.listen.StandardListenerManager;
 import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.apache.zookeeper.Watcher.Event.EventType;
 import org.apache.zookeeper.data.Stat;
@@ -31,7 +32,7 @@ public class PersistentWatcher implements Closeable {
   private final String path;
   private final ScheduledExecutorService executor;
   private final CuratorWatcher watcher;
-  private final ListenerContainer<EventListener> listeners;
+  private final StandardListenerManager<EventListener> listeners;
 
   PersistentWatcher(WatcherFactory parent,
                     final String path) {
@@ -56,7 +57,7 @@ public class PersistentWatcher implements Closeable {
         fetchInExecutor();
       }
     };
-    this.listeners = new ListenerContainer<>();
+    this.listeners = StandardListenerManager.standard();
   }
 
 
@@ -157,7 +158,6 @@ public class PersistentWatcher implements Closeable {
     executor.submit(() -> {
       listeners.forEach(listener -> {
         listener.newEvent(event);
-        return null;
       });
     });
   }


### PR DESCRIPTION
This is a change coming from zk to prepare everyone for an upcoming upgrade to a newer version of curator. The ListenerContainer class no longer exists in the newer curator version but luckily its replacement StandardListenerManager exists in the current curator version. Let me know if there is any testing that can be added/done here to make sure this is still working as expected.