### PR TITLE
Check if connection is closed before processing an event on the watcher

### DIFF
--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -50,6 +50,7 @@ public class PersistentWatcher implements Closeable {
 
     // keep a reference to the watcher so we don't add duplicates (Curator uses a set)
     this.watcher = event -> {
+      // Make sure the connection is open, otherwise we'll throw an error trying to submit to the executor
       if(!closed.get()) {
         if (event.getType() == EventType.NodeDeleted) {
           lastVersion.set(-1);

--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -50,11 +50,13 @@ public class PersistentWatcher implements Closeable {
 
     // keep a reference to the watcher so we don't add duplicates (Curator uses a set)
     this.watcher = event -> {
-      if (event.getType() == EventType.NodeDeleted) {
-        lastVersion.set(-1);
-        notifyListeners(Event.nodeDeleted());
-      } else {
-        fetchInExecutor();
+      if(!closed.get()) {
+        if (event.getType() == EventType.NodeDeleted) {
+          lastVersion.set(-1);
+          notifyListeners(Event.nodeDeleted());
+        } else {
+          fetchInExecutor();
+        }
       }
     };
     this.listeners = StandardListenerManager.standard();

--- a/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/PersistentWatcher.java
@@ -51,7 +51,7 @@ public class PersistentWatcher implements Closeable {
     // keep a reference to the watcher so we don't add duplicates (Curator uses a set)
     this.watcher = event -> {
       // Make sure the connection is open, otherwise we'll throw an error trying to submit to the executor
-      if(!closed.get()) {
+      if (!closed.get()) {
         if (event.getType() == EventType.NodeDeleted) {
           lastVersion.set(-1);
           notifyListeners(Event.nodeDeleted());


### PR DESCRIPTION
There is a bug where Ringleader receives a `CLOSED` event it calls `close` in the PersistentWatcher which shuts down the executor. If there are events that need to be processed after that they'll fail because they'll be rejected by the executor. This PR checks if the connection is closed before submitting an event to the executor