### PR TITLE
upgrade basepom to 59.6, apply code formatting changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,44 +5,20 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.3</version>
+    <version>59.6-SNAPSHOT</version>
   </parent>
 
   <artifactId>Ringleader</artifactId>
   <version>0.1.11-SNAPSHOT</version>
 
   <properties>
-    <dep.curator.version>4.2.0</dep.curator.version>
-
     <basepom.check.skip-dependency-versions-check>true</basepom.check.skip-dependency-versions-check>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.apache.curator</groupId>
-        <artifactId>curator-test</artifactId>
-        <!--
-        Hardcode this to an older version because we're still on ZooKeeper client 3.4.x
-        https://issues.apache.org/jira/browse/CURATOR-428?focusedCommentId=16106765&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16106765
-        -->
-        <version>2.13.0</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.curator</groupId>
@@ -51,6 +27,18 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-framework</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper-jute</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -68,6 +56,26 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${project.basedir}/spotbugs-exclude-filter.xml</excludeFilterFile>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
   <scm>
     <connection>scm:git:git@github.com:HubSpot/Ringleader.git</connection>

--- a/spotbugs-exclude-filter.xml
+++ b/spotbugs-exclude-filter.xml
@@ -1,0 +1,7 @@
+<FindBugsFilter>
+    <Match>
+        <Class name="com.hubspot.ringleader.watcher.PersistentWatcher"/>
+        <Bug pattern="CT_CONSTRUCTOR_THROW"/>
+    </Match>
+</FindBugsFilter>
+

--- a/src/main/java/com/hubspot/ringleader/watcher/Event.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/Event.java
@@ -3,8 +3,10 @@ package com.hubspot.ringleader.watcher;
 import org.apache.zookeeper.data.Stat;
 
 public class Event {
+
   public enum Type {
-    NODE_UPDATED, NODE_DELETED
+    NODE_UPDATED,
+    NODE_DELETED,
   }
 
   private final Type type;

--- a/src/main/java/com/hubspot/ringleader/watcher/EventListener.java
+++ b/src/main/java/com/hubspot/ringleader/watcher/EventListener.java
@@ -1,6 +1,5 @@
 package com.hubspot.ringleader.watcher;
 
 public interface EventListener {
-
   void newEvent(Event event);
 }


### PR DESCRIPTION
This bumps the dependency version of curator from 4.x to 5.x, as defined in [basepom](https://github.com/HubSpot/basepom/blob/0064112f8a2aed9a3ed85deb76d0f353dd748259/pom.xml#L132) 
